### PR TITLE
feat: replace and delete

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,0 +1,41 @@
+name: Pull Request
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  unit:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+      - name: Go Private Modules
+        run: |
+          GOPRIVATE=${GOPRIVATE:=github.com/NSXBet/*}
+          echo "GOPRIVATE=$GOPRIVATE" >> $GITHUB_ENV
+          git config --global url."https://${{ secrets.GHA_PAT }}@github.com/".insteadOf "https://github.com/"
+      - name: Test
+        env:
+          ENVIRONMENT: ci
+        run: make test
+  Generate:
+    name: Generate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+      - name: Go Private Modules
+        run: |
+          GOPRIVATE=${GOPRIVATE:=github.com/NSXBet/*}
+          echo "GOPRIVATE=$GOPRIVATE" >> $GITHUB_ENV
+          git config --global url."https://${{ secrets.GHA_PAT }}@github.com/".insteadOf "https://github.com/"
+      - name: Generate
+        run: |
+          make gen && (git diff --quiet --exit-code || (echo "❌ Uncommitted changes detected. Please run <code>make gen</code> and commit them." >> $GITHUB_STEP_SUMMARY && echo "<pre lang=\"diff\"><code>$(git diff)</code></pre>" >> $GITHUB_STEP_SUMMARY && exit 1))

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,19 @@
 APP_NAME=go-cache-manager
 
 .PHONY: gen
-gen:
+gen: gen-setup
 	@go build -o bin/protoc-gen-$(APP_NAME) main.go
 	@cd ./protos && PATH="${PWD}/bin:${PATH}" buf generate
 
 .PHONY: test
 test: gen
 	@go test -v ./...
+
+.PHONY: gen-setup
+gen-setup:
+	@if [ -x "$$(command -v buf)" ]; then \
+		: ; \
+	else \
+	    echo "buf could not be found! Installing..."; \
+	    go install github.com/bufbuild/buf/cmd/buf@latest; \
+	fi

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ service UserCache {
   // This will generate a `.GetUserDetails` method to either return cached data or refresh and return,
   // and a `.RefreshUserDetails` method to refresh the cache, independently of the cache state,
   // while also returning the data.
+  // We'll also generate a `.ReplaceUserDetails` method to replace the cache data with the given data.
+  // Lastly we'll get a `DeleteUserDetails` method to delete the cache data.
   rpc UserDetails(UserDetailsRequest) returns (UserDetailsResponse) {}
 
   // You can add as many cache methods as you want here.

--- a/gen/go/nsx/testapp/user_cache_manager.pb.go
+++ b/gen/go/nsx/testapp/user_cache_manager.pb.go
@@ -51,7 +51,7 @@ func (cm *UserCacheManager) GetUserDetails(
 	return cm.userCacheManager_UserDetails.Get(ctx, input, dependencies...)
 }
 
-// Eagerly refresh the cache for the method that:
+// Eagerly Refresh the cache for the method that:
 // UserDetails returns the user details for the given user_id from the cache.
 // This method is a test of a multi-line comment.
 // It should not break other lines.
@@ -60,7 +60,45 @@ func (cm *UserCacheManager) RefreshUserDetails(
 	input *UserDetailsRequest,
 	dependencies ...map[string]any,
 ) (*UserDetailsResponse, error) {
-	return cm.userCacheManager_UserDetails.Refresh(ctx, input, dependencies...)
+	return cm.userCacheManager_UserDetails.Refresh(
+		ctx,
+		input,
+		dependencies...,
+	)
+}
+
+// Eagerly Replace the cache for the method that:
+// UserDetails returns the user details for the given user_id from the cache.
+// This method is a test of a multi-line comment.
+// It should not break other lines.
+func (cm *UserCacheManager) ReplaceUserDetails(
+	ctx context.Context,
+	input *UserDetailsRequest,
+	newValue *UserDetailsResponse,
+	dependencies ...map[string]any,
+) (*UserDetailsResponse, error) {
+	return cm.userCacheManager_UserDetails.Replace(
+		ctx,
+		input,
+		newValue,
+		dependencies...,
+	)
+}
+
+// Eagerly Delete the cache for the method that:
+// UserDetails returns the user details for the given user_id from the cache.
+// This method is a test of a multi-line comment.
+// It should not break other lines.
+func (cm *UserCacheManager) DeleteUserDetails(
+	ctx context.Context,
+	input *UserDetailsRequest,
+	dependencies ...map[string]any,
+) error {
+	return cm.userCacheManager_UserDetails.Delete(
+		ctx,
+		input,
+		dependencies...,
+	)
 }
 
 type TournamentCacheManager struct {
@@ -103,5 +141,35 @@ func (cm *TournamentCacheManager) RefreshMainTournaments(
 	input *MainTournamentsRequest,
 	dependencies ...map[string]any,
 ) (*MainTournamentsResponse, error) {
-	return cm.tournamentCacheManager_MainTournaments.Refresh(ctx, input, dependencies...)
+	return cm.tournamentCacheManager_MainTournaments.Refresh(
+		ctx,
+		input,
+		dependencies...,
+	)
+}
+
+func (cm *TournamentCacheManager) ReplaceMainTournaments(
+	ctx context.Context,
+	input *MainTournamentsRequest,
+	newValue *MainTournamentsResponse,
+	dependencies ...map[string]any,
+) (*MainTournamentsResponse, error) {
+	return cm.tournamentCacheManager_MainTournaments.Replace(
+		ctx,
+		input,
+		newValue,
+		dependencies...,
+	)
+}
+
+func (cm *TournamentCacheManager) DeleteMainTournaments(
+	ctx context.Context,
+	input *MainTournamentsRequest,
+	dependencies ...map[string]any,
+) error {
+	return cm.tournamentCacheManager_MainTournaments.Delete(
+		ctx,
+		input,
+		dependencies...,
+	)
 }

--- a/pkg/gocachemanager/sdk.go
+++ b/pkg/gocachemanager/sdk.go
@@ -114,3 +114,9 @@ func (gcw *GoCacheWrapper) Set(ctx context.Context, key []byte, value []byte) er
 
 	return gcw.cacheManager.Set(ctx, strKey, value, store.WithExpiration(gcw.expiration))
 }
+
+func (gcw *GoCacheWrapper) Delete(ctx context.Context, key []byte) error {
+	strKey := gcw.getKey(key)
+
+	return gcw.cacheManager.Delete(ctx, strKey)
+}


### PR DESCRIPTION
## Introduction

This commit adds replace and delete methods so cache managers can do
both operations.

Replace allows you to imperatively change what's stored in the cache for
a given key. This use case is very common when you are listening to
events that need to actively update the cache.

Delete allows you to remove data from the cache actively. The use case
here is when you want to invalidate data from the cache.

## Testing

Unit tests were added to cover the new methods.
