### PR TITLE
fix: GoCacheWrapper hold cache expiration value provide by options

### DIFF
--- a/pkg/gocachemanager/sdk.go
+++ b/pkg/gocachemanager/sdk.go
@@ -54,11 +54,10 @@ func NewGoCacheWrapper(
 	if settings.redisConnection != "" {
 		redisClient := redis.NewClient(&redis.Options{Addr: settings.redisConnection})
 
-		// Initialize stores
-		expiration := 5 * time.Second
 		if settings.expiration != 0 {
 			expiration = settings.expiration
 		}
+
 		redisStore := redis_store.NewRedis(redisClient, store.WithExpiration(expiration))
 
 		caches = append(caches, cache.New[[]byte](redisStore))


### PR DESCRIPTION
## 🚀 Description
The current version is not considering the cache expiration value passed by `CacheSettings` causing unexpected behavior because the expiration variable are shadowed. So this PR comes to remove the unnecessary expiration assignment.

## 🔍 Testing
1. Run on CLI `make test`