### PR TITLE
fix: avoiding duplicate metrics collector registration

### DIFF
--- a/pkg/gocachemanager/options.go
+++ b/pkg/gocachemanager/options.go
@@ -19,6 +19,9 @@ type CacheSettings struct {
 	// prometheusPrefix will be used whenever sending cache metrics to Prometheus.
 	prometheusPrefix string
 
+	// prometheusNamespace will be used whenever sending cache metrics to Prometheus.
+	prometheusNamespace string
+
 	// expiration is the expiration time for the cache.
 	// Defaults to 5 seconds.
 	expiration time.Duration
@@ -53,6 +56,13 @@ func WithSkipInMemoryCache() CacheOption {
 func WithPrometheusPrefix(prometheusPrefix string) CacheOption {
 	return func(settings *CacheSettings) {
 		settings.prometheusPrefix = prometheusPrefix
+	}
+}
+
+// WithPrometheusNamespace is a cache option for setting the Prometheus namespace.
+func WithPrometheusNamespace(prometheusNamespace string) CacheOption {
+	return func(settings *CacheSettings) {
+		settings.prometheusNamespace = prometheusNamespace
 	}
 }
 

--- a/pkg/gocachemanager/sdk.go
+++ b/pkg/gocachemanager/sdk.go
@@ -73,7 +73,13 @@ func NewGoCacheWrapper(
 	if settings.prometheusPrefix == "" {
 		cacheManager = cache.NewChain(caches...)
 	} else {
-		promMetrics := metrics.NewPrometheus(settings.prometheusPrefix)
+		var promOpts []metrics.PrometheusOption
+
+		if len(settings.prometheusNamespace) > 0 {
+			promOpts = append(promOpts, metrics.WithNamespace(settings.prometheusNamespace))
+		}
+
+		promMetrics := metrics.NewPrometheus(settings.prometheusPrefix, promOpts...)
 
 		cacheManager = cache.NewMetric(
 			promMetrics,


### PR DESCRIPTION
## 🚀 Description
This PR solves duplicate registration of prometheus collector when the project has more than one cache service, because providing prometheus prefix is not sufficient to differentiate one service of other. 

Error:
<img width="824" alt="image" src="https://github.com/user-attachments/assets/5c99e475-3fe4-4ac6-acfa-5ddc0b63f350">


So now we have `WithPrometheusNamespace` option to context each service cache metric collector.

## 🔍 Testing
1. Run on CLI `make test`