### PR TITLE
fix: modified cacheManager hold string values than bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,3 +352,23 @@ manager, err := usersvc.NewUserCacheManager(
     gocachemanager.WithExpiration(5 * time.Minute),
 )
 ```
+
+
+### WithGzip
+
+This option allows you to configure the cache manager to use data compression to reduce the payload before save it into cache
+
+```go
+manager, err := usersvc.NewUserCacheManager(
+    func(ctx context.Context, input *usersvc.UserDetailsRequest) (*usersvc.UserDetailsResponse, error) {
+        return &usersvc.UserDetailsResponse{
+            User: &usersvc.User{
+                UserId: input.UserId,
+                Name:   "Test User",
+                Email:  "
+            },
+        }, nil
+    },
+    gocachemanager.WithGzip(),
+)
+```

--- a/go.mod
+++ b/go.mod
@@ -7,10 +7,12 @@ require (
 	github.com/eko/gocache/lib/v4 v4.1.6
 	github.com/eko/gocache/store/redis/v4 v4.2.2
 	github.com/eko/gocache/store/ristretto/v4 v4.2.2
+	github.com/google/uuid v1.6.0
 	github.com/redis/go-redis/v9 v9.0.2
 	github.com/samber/lo v1.46.0
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go/modules/redis v0.32.0
+	golang.org/x/sync v0.7.0
 	google.golang.org/protobuf v1.34.2
 )
 
@@ -41,7 +43,6 @@ require (
 	github.com/golang/glog v1.1.2 // indirect
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/klauspost/compress v1.17.4 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
@@ -75,7 +76,6 @@ require (
 	golang.org/x/crypto v0.25.0 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/net v0.27.0 // indirect
-	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.22.0 // indirect
 	golang.org/x/text v0.16.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231016165738-49dd2c1f3d0b // indirect

--- a/pkg/gocachemanager/options.go
+++ b/pkg/gocachemanager/options.go
@@ -25,6 +25,10 @@ type CacheSettings struct {
 	// expiration is the expiration time for the cache.
 	// Defaults to 5 seconds.
 	expiration time.Duration
+
+	// gzip enable value compression
+	// Defaults is false
+	gzip bool
 }
 
 // DefaultCacheSettings returns the default cache settings.
@@ -75,5 +79,12 @@ func WithInMemoryCacheSize(inMemoryCacheSize int64) CacheOption {
 func WithExpiration(expiration time.Duration) CacheOption {
 	return func(settings *CacheSettings) {
 		settings.expiration = expiration
+	}
+}
+
+// WithGzip is a cache option for enable byte compression.
+func WithGzip() CacheOption {
+	return func(settings *CacheSettings) {
+		settings.gzip = true
 	}
 }


### PR DESCRIPTION
## 🚀 Description
In the current version redis is not handling byte data properly, so this PR have changes to save data encoded in base64 to be more compatible with the cache chain. Data compression has also been added to compact data before save.

## 🔍 Testing
1. Run on CLI `make test`