### PR TITLE
feat: add Redis password and TLS support

### DIFF
--- a/pkg/gocachemanager/options.go
+++ b/pkg/gocachemanager/options.go
@@ -29,6 +29,12 @@ type CacheSettings struct {
 	// gzip enable value compression
 	// Defaults is false
 	gzip bool
+
+	// Redis Password
+	redisPassword string
+
+	// Redis TLS
+	redisTLS bool
 }
 
 // DefaultCacheSettings returns the default cache settings.
@@ -86,5 +92,19 @@ func WithExpiration(expiration time.Duration) CacheOption {
 func WithGzip() CacheOption {
 	return func(settings *CacheSettings) {
 		settings.gzip = true
+	}
+}
+
+// WithRedisPassword is a cache option for setting the Redis password.
+func WithRedisPassword(redisPassword string) CacheOption {
+	return func(settings *CacheSettings) {
+		settings.redisPassword = redisPassword
+	}
+}
+
+// WithRedisTLS is a cache option for setting the Redis TLS.
+func WithRedisTLS(redisTLS bool) CacheOption {
+	return func(settings *CacheSettings) {
+		settings.redisTLS = redisTLS
 	}
 }

--- a/pkg/gocachemanager/sdk.go
+++ b/pkg/gocachemanager/sdk.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/tls"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -56,7 +57,18 @@ func NewGoCacheWrapper(
 	}
 
 	if settings.redisConnection != "" {
-		redisClient := redis.NewClient(&redis.Options{Addr: settings.redisConnection})
+		redisOptions := &redis.Options{Addr: settings.redisConnection}
+		if settings.redisPassword != "" {
+			redisOptions.Password = settings.redisPassword
+		}
+
+		if settings.redisTLS {
+			redisOptions.TLSConfig = &tls.Config{
+				MinVersion: tls.VersionTLS12,
+			}
+		}
+
+		redisClient := redis.NewClient(redisOptions)
 
 		if settings.expiration != 0 {
 			expiration = settings.expiration


### PR DESCRIPTION
- Add redisPassword and redisTLS fields to CacheSettings
- Add WithRedisPassword and WithRedisTLS cache options
- Configure Redis client with password authentication when provided
- Enable TLS 1.2+ for Redis connections when redisTLS is enabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added Redis password authentication support, enabling secure credential management for cache connections.
* Introduced TLS encryption for Redis connections with TLS 1.2 minimum version requirement.
* New configuration options provide flexible security settings for the cache manager without disrupting current implementations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->